### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -2,7 +2,8 @@ name: Deploy web
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
 
 jobs:
   build:
@@ -20,19 +21,21 @@ jobs:
       - name: Cache WASM build
         uses: actions/cache@v3
         with:
-          path: packages/create-ua-web/template/rust_backend/target
+          path: packages/create-web/template/rust_backend/target
           key: rust_backend
 
       - name: Build ua-components
-        working-directory: packages/ua_components
+        working-directory: packages/components
         run: |
           pnpm install
           pnpm build
 
       - name: Build uatp_template
-        working-directory: packages/create-ua-web/template/web
+        working-directory: packages/create-web/template/web
+        run: |
           pnpm install
-          pnpm wasm-release
+          pnpm rust
+          pnpm python
           BASE_PATH=/web-app-template pnpm build
           # Unclear why this is necessary
           cp -Rv build/assets/ build/_app/immutable/workers/
@@ -41,4 +44,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: packages/create-ua-web/template/web/build
+          publish_dir: packages/create-web/template/web/build

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -29,13 +29,13 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Build ua-components
+      - name: Build @uatp/components
         working-directory: packages/components
         run: |
           pnpm install
           pnpm build
 
-      - name: Build uatp_template
+      - name: Build @uatp/template
         working-directory: packages/create-web/template/web
         run: |
           pnpm install

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
@@ -45,7 +48,8 @@ jobs:
           # Unclear why this is necessary
           cp -Rv build/assets/ build/_app/immutable/workers/
 
-      - name: Publish
+      - name: Publish (if on main branch)
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -24,6 +24,11 @@ jobs:
           path: packages/create-web/template/rust_backend/target
           key: rust_backend
 
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
       - name: Build ua-components
         working-directory: packages/components
         run: |


### PR DESCRIPTION
The GH pages deployment was bugged (the workflow responsible for it, `web.yml`, is configured to only run on the main branch, so this wasn't detected before my previous PR was merged).

I've updated the workflow to run correctly here, and additionally verified that it works (I temporarily enabled the workflow for my development branch, meaning that the gh-pages branch now has the new template). You can see the working version at: https://urban-analytics-technology-platform.github.io/web-app-template/#0.56/0/0

To prevent this problem from happening again in the future, I've enabled the workflow in `web.yml` for PRs to main. However, the final publish step only runs for commits that are actually pushed the main branch. You can see this in action on this PR itself.